### PR TITLE
perf: improve the performance of `randomBytes`

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -115,7 +115,6 @@ func randomBytes(n int) []byte {
 	)
 
 	b := make([]byte, n)
-
 	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
 		if remain == 0 {
 			cache, remain = src.Int63(), letterIdxMax

--- a/csrf.go
+++ b/csrf.go
@@ -103,19 +103,19 @@ type Options struct {
 	ErrorFunc func(w http.ResponseWriter)
 }
 
-const (
-	letterBytes   = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	letterIdxBits = 6                    // 6 bits to represent a letter index
-	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
-	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
-)
-
 var src = rand.NewSource(time.Now().UnixNano())
 
 // randomBytes generates n random []byte.
 func randomBytes(n int) []byte {
+	const (
+		letterBytes   = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+		letterIdxBits = 6                    // 6 bits to represent a letter index
+		letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+		letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+	)
+
 	b := make([]byte, n)
-	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+
 	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
 		if remain == 0 {
 			cache, remain = src.Int63(), letterIdxMax


### PR DESCRIPTION
BenchmarkRandomBytes
BenchmarkRandomBytes-12       	 1208862	       962.8 ns/op
BenchmarkRandomBytesNew
BenchmarkRandomBytesNew-12    	25269285	        47.34 ns/op

### Describe the pull request

A clear and concise description of what the pull request is about, i.e. what problem should be fixed? 

Link to the issue: <!-- paste the issue link here, or put "n/a" if not applicable -->

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
