### PR TITLE
ci: run Go tests with `-shuffle=on`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with coverage
-        run: go test -v -race -coverprofile=coverage -covermode=atomic ./... -run !TestGobSerialization
+        run: go test -shuffle=on -v -race -coverprofile=coverage -covermode=atomic ./... -run !TestGobSerialization
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1.5.0
         with:
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with coverage
-        run: go test -v -race -coverprofile=coverage -covermode=atomic ./...
+        run: go test -shuffle=on -v -race -coverprofile=coverage -covermode=atomic ./...
         env:
           REDIS_HOST: localhost
           REDIS_PORT: 6379


### PR DESCRIPTION
Updates CI to run Go tests with `-shuffle=on`

[_Created by Sourcegraph batch change `unknwon/run-go-tests-with-shuffle`._](https://cs.unknwon.dev/users/unknwon/batch-changes/run-go-tests-with-shuffle)